### PR TITLE
Count must be of type Countable|array

### DIFF
--- a/core/components/jsonformbuilder/model/jsonformbuilder/JsonFormBuilder.class.php
+++ b/core/components/jsonformbuilder/model/jsonformbuilder/JsonFormBuilder.class.php
@@ -1894,7 +1894,7 @@ class JsonFormBuilder extends JsonFormBuilderCore {
 
                     $s_extraClasses = '';
                     $a_exClasses = $o_el->getExtraClasses();
-                    if (count($a_exClasses) > 0) {
+                    if (is_countable($a_exClasses) && count($a_exClasses) > 0) {
                         $s_extraClasses = ' ' . implode(' ', $o_el->getExtraClasses());
                     }
 


### PR DESCRIPTION
When using PHP 8.2 (probably earlier) a TypeError is thrown because count gets passed the value null.